### PR TITLE
feat(lazygit): add commitizen as dependency for lazygit

### DIFF
--- a/roles/lazygit/tasks/MacOSX.yml
+++ b/roles/lazygit/tasks/MacOSX.yml
@@ -1,4 +1,12 @@
 ---
+
+- name: "Installing dependencies"
+  community.general.homebrew:
+    name: "{{ item }}"
+    state: present
+    update_homebrew: true
+  loop: "{{ lazygit_dependencies }}"
+
 - name: "Installing lazygit"
   community.general.homebrew:
     name: lazygit

--- a/roles/lazygit/vars/main.yml
+++ b/roles/lazygit/vars/main.yml
@@ -1,0 +1,2 @@
+lazygit_dependencies:
+  - commitizen # < this used as default commit tool and binded to short-key


### PR DESCRIPTION
Lazygit has a custom shortcut, which calls commitizen. Without commitizen, the command will fail. This change ensures, that commitizen installed alongside with lazygit.

Issue: #18