### PR TITLE
fix(zsh): fix load order for environment variables

### DIFF
--- a/roles/zsh/files/.zshrc
+++ b/roles/zsh/files/.zshrc
@@ -39,7 +39,7 @@ autoload -Uz compinit && compinit
 
 # source of shell functions must be after compinit
 # REASON: some shell functions use cmpdeff, which is being loaded by compinit
-for type in "alias" "function" "var"; do
+for type in "var" "function" "alias"; do
   dir="${HOME}/.config/zsh/${type}"
   [ -d "$dir" ] || continue
   for file in "$dir"/*; do


### PR DESCRIPTION
Environmnet variables must be loaded before aliases, since aliases rely on on some user defined environment variables.

Issue: #22