### PR TITLE
fix(starship): remove python module from starship

### DIFF
--- a/roles/starship/files/starship.toml
+++ b/roles/starship/files/starship.toml
@@ -147,12 +147,6 @@ symbol = ""
 
 format = '[[ $symbol( $version) ]]($style)'
 
-[python]
-symbol = ""
-
-format = '[[ $symbol( $version) ]]($style)'
-
-
 [docker_context]
 symbol = ""
 format = '[ $symbol( $context) ]($style)'


### PR DESCRIPTION
This change removes python module from starship configuration, which led to the crash in projects containing python

Issue: #26