### PR TITLE
fix(zoxide): fix missing package installation

### DIFF
--- a/roles/zoxide/tasks/MacOSX.yml
+++ b/roles/zoxide/tasks/MacOSX.yml
@@ -5,3 +5,9 @@
     state: present
     update_homebrew: true
   loop: "{{ zoxide_dependencies }}"
+
+- name: Installing zoxide
+  community.general.homebrew:
+    name: zoxide
+    state: present
+    update_homebrew: true


### PR DESCRIPTION
Latest iteration was only installing `zoxide` dependencies, but not zoxide itself. This change adds missing installation of zoxide.

Issue: #31